### PR TITLE
Add unpublish methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ window.nearby.publish(message, function(success) {
     console.log(error)
 })
 ```
+### Un-Publish
+```
+window.nearby.unpublish(message, function(success) {
+    console.log(success)
+}, function(error) {
+    console.log(error)
+})
+```
 
 ### Unsubscribe
 ```
@@ -88,6 +96,14 @@ this.subscribtion.unsubscribe()
 import { GoogleNearby } from '@ionic-native/google-nearby';
 constructor(private nearby: GoogleNearby) { }
 this.nearby.publish(message).then(result => {
+    console.log(result)
+})
+```
+### Un-Publish
+```
+import { GoogleNearby } from '@ionic-native/google-nearby';
+constructor(private nearby: GoogleNearby) { }
+this.nearby.unpublish(message).then(result => {
     console.log(result)
 })
 ```

--- a/www/nearby.js
+++ b/www/nearby.js
@@ -13,7 +13,7 @@ publish: function(message, successCallback, errorCallback) {
     },
 
 unpublish: function(successCallback, errorCallback) {
-        exec(successCallback, errorCallback, "NearbyPlugin", "unpublish", message);
+        exec(successCallback, errorCallback, "NearbyPlugin", "unpublish");
     }
 };
 

--- a/www/nearby.js
+++ b/www/nearby.js
@@ -10,9 +10,12 @@ unsubscribe: function (successCallback, errorCallback) {
     
 publish: function(message, successCallback, errorCallback) {
         exec(successCallback, errorCallback, "NearbyPlugin", "publish", message);
-    }
-}
+    },
 
+unpublish: function(successCallback, errorCallback) {
+        exec(successCallback, errorCallback, "NearbyPlugin", "unpublish", message);
+    }
+};
 
 module.exports = nearby;
 


### PR DESCRIPTION
[According to the documentation on this API](https://developers.google.com/nearby/messages/android/pub-sub#unpublish_a_message), publishing a message should always be accompanied by un-publishing the same message because the nearby API can be very battery intensive. I added a call to that method as shown in the linked documentation.

I've never done any development for cordova plugins, so I don't know how to test this. I just copied the format from your other methods, and I assume it should work. Please test this before accepting it, because I don't know how.